### PR TITLE
Delete userId of getWork Query argument

### DIFF
--- a/Portal/resolver/query/getWork/request-mapping.template
+++ b/Portal/resolver/query/getWork/request-mapping.template
@@ -2,8 +2,6 @@
     "version": "2017-02-28",
     "operation": "GetItem",
     "key": {
-      "id": $util.dynamodb.toStringJson($ctx.args.id),
-      "userId": $util.dynamodb.toStringJson($ctx.args.userId)
+      "id": $util.dynamodb.toStringJson($ctx.args.id)
     }
 }
-

--- a/Portal/resolver/query/getWork/response-mapping.template
+++ b/Portal/resolver/query/getWork/response-mapping.template
@@ -1,2 +1,1 @@
 $util.toJson($ctx.result)
-

--- a/Portal/schema.graphql
+++ b/Portal/schema.graphql
@@ -24,7 +24,7 @@ input PopularTagInput {
 type Query {
 	getUser(id: ID!): User
 	listUsers(limit: Int, exclusiveStartKey: ID): UserConnection
-	getWork(id: ID!, userId: ID!): Work
+	getWork(id: ID!): Work
 	listWorks(limit: Int, exclusiveStartKey: ID, option: WorkQueryOption): WorkConnection
 	listPopularTags: [PopularTag]
 }


### PR DESCRIPTION
# Delete userId of getWork Query argument
## Overview
getWork Queryの引数のuserIdが不要なため削除.

## Changes
- getWork Query on schema.graphql
- getWork resolver

## Supplement
本番環境デプロイ済み